### PR TITLE
HG-70: Added IPv6 support

### DIFF
--- a/apps/hellgate/src/hellgate.erl
+++ b/apps/hellgate/src/hellgate.erl
@@ -48,10 +48,11 @@ init([]) ->
     }}.
 
 get_api_child_spec(MachineHandlers) ->
+    {ok, Ip} = inet:parse_address(genlib_app:env(?MODULE, ip, "::")),
     woody_server:child_spec(
         ?MODULE,
         #{
-            ip => hg_utils:get_hostname_ip(genlib_app:env(?MODULE, host, "0.0.0.0")),
+            ip => Ip,
             port => genlib_app:env(?MODULE, port, 8022),
             net_opts => [],
             event_handler => hg_woody_event_handler,

--- a/config/sys.config
+++ b/config/sys.config
@@ -7,7 +7,7 @@
     ]},
 
     {hellgate, [
-        {host, "0.0.0.0"},
+        {ip, "::"},
         {port, 8022},
         {automaton_service_url, <<"http://machinegun:8022/v1/automaton">>},
         {eventsink_service_url, <<"http://machinegun:8022/v1/event_sink">>},


### PR DESCRIPTION
Changed parameter "host" in sys.config to "ip" to allow specify interface directly and choose IPv6 (default) or IPv4
