### PR TITLE
Fix merchant refund terms acceptance

### DIFF
--- a/apps/hellgate/src/hg_invoice_payment.erl
+++ b/apps/hellgate/src/hg_invoice_payment.erl
@@ -445,13 +445,20 @@ validate_refund_time(RefundCreatedAt, PaymentCreatedAt, TimeSpanSelector, VS, Re
 
 collect_refund_varset(
     #domain_PaymentRefundsServiceTerms{
-        partial_refunds = PartialRefundsServiceTerms
+        payment_methods  = PaymentMethodSelector,
+        partial_refunds  = PartialRefundsServiceTerms
     },
     VS,
     Revision
 ) ->
-    PartialRefundsVS = collect_partial_refund_varset(PartialRefundsServiceTerms, VS, Revision),
-    VS#{refunds => PartialRefundsVS};
+    RPMs = reduce_selector(payment_methods, PaymentMethodSelector, VS, Revision),
+    case ordsets:is_element(hg_payment_tool:get_method(maps:get(payment_tool, VS)), RPMs) of
+        true ->
+            RVS = collect_partial_refund_varset(PartialRefundsServiceTerms, VS, Revision),
+            VS#{refunds => RVS};
+        false ->
+            VS
+    end;
 collect_refund_varset(undefined, VS, _Revision) ->
     VS.
 

--- a/apps/hellgate/test/hg_invoice_tests_SUITE.erl
+++ b/apps/hellgate/test/hg_invoice_tests_SUITE.erl
@@ -2418,22 +2418,7 @@ construct_domain_fixture() ->
                             {provider, settlement},
                             ?share(21, 1000, operation_amount)
                         )
-                    ]},
-                    refunds = #domain_PaymentRefundsProvisionTerms{
-                        cash_flow = {value, [
-                            ?cfpost(
-                                {merchant, settlement},
-                                {provider, settlement},
-                                ?share(1, 1, operation_amount)
-                            )
-                        ]},
-                        partial_refunds = #domain_PartialRefundsProvisionTerms{
-                            cash_limit = {value, ?cashrng(
-                                {inclusive, ?cash(        10, <<"RUB">>)},
-                                {exclusive, ?cash(1000000000, <<"RUB">>)}
-                            )}
-                        }
-                    }
+                    ]}
                 }
             }
         }},


### PR DESCRIPTION
It was incorrect not to consider payment methods restriction when evaluating refund terms.