### PR TITLE
HG-468 Remove temporary reindex MG call handler

### DIFF
--- a/apps/hellgate/src/hg_party_machine.erl
+++ b/apps/hellgate/src/hg_party_machine.erl
@@ -285,16 +285,7 @@ handle_call({revoke_claim, ID, ClaimRevision, Reason}, AuxSt, St) ->
         [finalize_claim(Claim, Timestamp)],
         AuxSt,
         St
-    );
-
-handle_call(rebuild_index, AuxSt, _St) ->
-    {
-        {ok, ok},
-        #{
-            events  => [],
-            auxst   => wrap_aux_state(AuxSt)
-        }
-    }.
+    ).
 
 publish_party_event(Source, {ID, Dt, Ev = ?party_ev(_)}) ->
     #payproc_Event{id = ID, source = Source, created_at = Dt, payload = Ev}.


### PR DESCRIPTION
Remove reindex machine call handler from rbkmoney/hellgate#304

This reverts commit 89464944b0578e5590b7f2e3a330602fd76e0996.