### PR TITLE
Revert "AAA-54: Upgrade woody (#354)"

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -81,7 +81,7 @@
  {<<"unicode_util_compat">>,{pkg,<<"unicode_util_compat">>,<<"0.4.1">>},3},
  {<<"woody">>,
   {git,"git@github.com:rbkmoney/woody_erlang.git",
-       {ref,"6136395b87758884863fdacfda3899195aa4eb39"}},
+       {ref,"649a8aba300d5ce3ada2aacf4c55e44011169dce"}},
   0},
  {<<"woody_user_identity">>,
   {git,"git@github.com:rbkmoney/woody_erlang_user_identity.git",


### PR DESCRIPTION
This reverts commit 74c5fc50c5a2da84de9546705abce8eb4cfe87dd.

Потому что

```
{"@severity":"info","@timestamp":"2019-08-26T11:46:07.230287Z","message":"[... ... ...][server] handling result: Party{id = '...', contact_info = PartyContactInfo{email = '...'}, created_at = '...', blocking = Blocking{unblocked = Unblocked{reason = '', since = '...'}}, suspension = Suspension{active = Active{since = '...'}}, contractors = #{}, contracts = #{'...' => Contract{id = '...', payment_institution = PaymentInstitutionRef{id = ...}, created_at = '...', status = ContractStatus{active = ContractActive{}}, terms = TermSetHierarchyRef{id = ...}, adjustments = [], payout_tools = [PayoutTool{id = '...', created_at = '...', currency = CurrencyRef{symbolic_code = '...'}, payout_tool_info = PayoutToolInfo{russian_bank_account = RussianBankAccount{account = '...', bank_name = '...', bank_post_account = '...', bank_bik = '...'}}}], legal_agreement = LegalAgreement{signed_at = '...', legal_agreement_id = '...'}, contractor = Contractor{legal_entity = LegalEntity{russian_legal_entity = RussianLegalEntity{registered_name = '...', registered_number = '...', inn = '...', actual_address = '...', post_address = '...', representative_position = '...', representative_full_name = '...', representative_document = '...', russian_bank_account = RussianBankAccount{account = '...', bank_name = '...', bank_post_account = '...', bank_bik = '...'}}}}}, '...' => Contract{id = '...', payment_institution = PaymentInstitutionRef{id = ...},
```