### PR TITLE
Refrain from synthesizing events on adjustment capture

### DIFF
--- a/apps/hellgate/src/hg_invoice_payment.erl
+++ b/apps/hellgate/src/hg_invoice_payment.erl
@@ -3157,14 +3157,6 @@ get_captured_cost(#domain_InvoicePaymentCaptured{cost = Cost}, _) when
 get_captured_cost(_, #domain_InvoicePayment{cost = Cost}) ->
     Cost.
 
--spec maybe_get_captured_cost(payment_status(), payment()) ->
-    cash().
-
-maybe_get_captured_cost({captured, Captured}, Payment) ->
-    get_captured_cost(Captured, Payment);
-maybe_get_captured_cost(_OtherStatus, #domain_InvoicePayment{cost = Cost}) ->
-    Cost.
-
 get_refund_session(#refund_st{sessions = []}) ->
     undefined;
 get_refund_session(#refund_st{sessions = [Session | _]}) ->

--- a/apps/hellgate/src/hg_invoice_payment.erl
+++ b/apps/hellgate/src/hg_invoice_payment.erl
@@ -3069,7 +3069,17 @@ apply_adjustment_effects(Adjustment, St) ->
         apply_adjustment_effect(cashflow, Adjustment, St)).
 
 apply_adjustment_effect(status, ?adjustment_target_status(Status), St = #st{payment = Payment}) ->
-    St#st{payment = Payment#domain_InvoicePayment{status = Status}};
+    case Status of
+        {captured, Capture} ->
+            St#st{payment = Payment#domain_InvoicePayment{
+                status = Status,
+                cost = get_captured_cost(Capture, Payment)
+            }};
+        _ ->
+            St#st{payment = Payment#domain_InvoicePayment{
+                status = Status
+            }}
+    end;
 apply_adjustment_effect(status, #domain_InvoicePaymentAdjustment{}, St) ->
     St;
 apply_adjustment_effect(cashflow, Adjustment, St) ->

--- a/apps/hellgate/src/hg_invoice_payment.erl
+++ b/apps/hellgate/src/hg_invoice_payment.erl
@@ -2827,14 +2827,6 @@ merge_change(Change = ?cash_flow_changed(Cashflow), #st{activity = Activity} = S
 merge_change(Change = ?rec_token_acquired(Token), #st{} = St, Opts) ->
     _ = validate_transition([{payment, processing_session}, {payment, finalizing_session}], Change, St, Opts),
     St#st{recurrent_token = Token};
-merge_change(?payment_status_changed(Status), #st{activity = {adjustment_pending, _ID}} = St, _Opts) ->
-    Payment = get_payment(St),
-    St#st{
-        payment = Payment#domain_InvoicePayment{
-            status = Status,
-            cost   = maybe_get_captured_cost(Status, Payment)
-        }
-    };
 merge_change(Change = ?payment_rollback_started(Failure), St, Opts) ->
     _ = validate_transition([{payment, S} || S <- [
         risk_scoring,

--- a/apps/hellgate/src/hg_invoice_payment.erl
+++ b/apps/hellgate/src/hg_invoice_payment.erl
@@ -1707,15 +1707,14 @@ finalize_adjustment(ID, Intent, St, Options) ->
     Adjustment = get_adjustment(ID, St),
     ok = assert_adjustment_status(processed, Adjustment),
     ok = finalize_adjustment_cashflow(Intent, Adjustment, St, Options),
-    {Status, AdditionalEvents} = case Intent of
+    Status = case Intent of
         capture ->
-            {?adjustment_captured(hg_datetime:format_now()),
-             get_ajustment_additional_events(Adjustment)};
+            ?adjustment_captured(hg_datetime:format_now());
         cancel ->
-            {?adjustment_cancelled(hg_datetime:format_now()), []}
+            ?adjustment_cancelled(hg_datetime:format_now())
     end,
     Event = ?adjustment_ev(ID, ?adjustment_status_changed(Status)),
-    {ok, {AdditionalEvents ++ [Event], hg_machine_action:new()}}.
+    {ok, {[Event], hg_machine_action:new()}}.
 
 prepare_adjustment_cashflow(Adjustment, St, Options) ->
     PlanID = construct_adjustment_plan_id(Adjustment, St, Options),
@@ -1792,14 +1791,6 @@ get_adjustment_cashflow(#domain_InvoicePaymentAdjustment{new_cash_flow = Cashflo
         }
     }
 ).
-
--spec get_ajustment_additional_events(adjustment()) ->
-    events().
-
-get_ajustment_additional_events(?adjustment_target_status(Status)) ->
-    [?payment_status_changed(Status)];
-get_ajustment_additional_events(_Adjustment) ->
-    [].
 
 %%
 
@@ -2994,7 +2985,7 @@ merge_change(Change = ?adjustment_ev(ID, Event), St, Opts) ->
     % TODO new cashflow imposed implicitly on the payment state? rough
     case get_adjustment_status(Adjustment) of
         ?adjustment_captured(_) ->
-            set_cashflow(get_adjustment_cashflow(Adjustment), St2);
+            apply_adjustment_effects(Adjustment, St2);
         _ ->
             St2
     end;
@@ -3080,6 +3071,17 @@ merge_adjustment_change(?adjustment_created(Adjustment), undefined) ->
     Adjustment;
 merge_adjustment_change(?adjustment_status_changed(Status), Adjustment) ->
     Adjustment#domain_InvoicePaymentAdjustment{status = Status}.
+
+apply_adjustment_effects(Adjustment, St) ->
+    apply_adjustment_effect(status, Adjustment,
+        apply_adjustment_effect(cashflow, Adjustment, St)).
+
+apply_adjustment_effect(status, ?adjustment_target_status(Status), St = #st{payment = Payment}) ->
+    St#st{payment = Payment#domain_InvoicePayment{status = Status}};
+apply_adjustment_effect(status, #domain_InvoicePaymentAdjustment{}, St) ->
+    St;
+apply_adjustment_effect(cashflow, Adjustment, St) ->
+    set_cashflow(get_adjustment_cashflow(Adjustment), St).
 
 validate_transition(Allowed, Change, St, Opts) ->
     Valid = is_transition_valid(Allowed, St),

--- a/apps/hellgate/test/hg_invoice_tests_SUITE.erl
+++ b/apps/hellgate/test/hg_invoice_tests_SUITE.erl
@@ -1772,11 +1772,13 @@ payment_adjustment_captured_from_failed(C) ->
     PartyClient = cfg(party_client, C),
     Shop = hg_client_party:get_shop(cfg(shop_id, C), PartyClient),
     ok = hg_ct_helper:adjust_contract(Shop#domain_Shop.contract_id, ?tmpl(1), PartyClient),
-    Captured = ?captured(),
-    AdjustmentParams = make_status_adjustment_params(Captured, AdjReason = <<"manual">>),
     Amount = 42000,
     InvoiceID = start_invoice(<<"rubberduck">>, make_due_date(3), Amount, C),
     PaymentParams = make_scenario_payment_params([temp, temp, temp, temp]),
+    CaptureAmount = Amount div 2,
+    CaptureCost = ?cash(CaptureAmount, <<"RUB">>),
+    Captured = {captured, #domain_InvoicePaymentCaptured{cost = CaptureCost}},
+    AdjustmentParams = make_status_adjustment_params(Captured, AdjReason = <<"manual">>),
     % start payment
     ?payment_state(?payment(PaymentID)) =
         hg_client_invoicing:start_payment(InvoiceID, PaymentParams, Client),
@@ -1851,10 +1853,8 @@ payment_adjustment_captured_from_failed(C) ->
     [
         ?payment_ev(PaymentID, ?adjustment_ev(AdjustmentID, ?adjustment_status_changed(?adjustment_captured(_))))
     ] = next_event(InvoiceID, Client),
-    ?assertMatch(
-        ?payment_state(?payment_w_status(PaymentID, Captured)),
-        hg_client_invoicing:get_payment(InvoiceID, PaymentID, Client)
-    ),
+    ?payment_state(Payment) = hg_client_invoicing:get_payment(InvoiceID, PaymentID, Client),
+    ?assertMatch(#domain_InvoicePayment{status = Captured, cost = CaptureCost}, Payment),
 
     % verify that cash deposited correctly everywhere
     % new cash flow must be calculated using initial domain and party revisions
@@ -1862,12 +1862,12 @@ payment_adjustment_captured_from_failed(C) ->
     PrvAccount2 = get_cashflow_account({provider, settlement}, CF2),
     SysAccount2 = get_cashflow_account({system, settlement}, CF2),
     MrcAccount2 = get_cashflow_account({merchant, settlement}, CF2),
-    Context = #{operation_amount => ?cash(Amount, <<"RUB">>)},
+    Context = #{operation_amount => CaptureCost},
     #domain_Cash{amount = MrcAmount1} = hg_cashflow:compute_volume(?merchant_to_system_share_1, Context),
-    MrcDiff = Amount - MrcAmount1,
+    MrcDiff = CaptureAmount - MrcAmount1,
     ?assertEqual(MrcDiff, maps:get(own_amount, MrcAccount2) - maps:get(own_amount, MrcAccount1)),
     #domain_Cash{amount = PrvAmount1} = hg_cashflow:compute_volume(?system_to_provider_share_initial, Context),
-    PrvDiff = PrvAmount1 - Amount,
+    PrvDiff = PrvAmount1 - CaptureAmount,
     ?assertEqual(PrvDiff, maps:get(own_amount, PrvAccount2) - maps:get(own_amount, PrvAccount1)),
     SysDiff = MrcAmount1 - PrvAmount1,
     ?assertEqual(SysDiff, maps:get(own_amount, SysAccount2) - maps:get(own_amount, SysAccount1)).


### PR DESCRIPTION
Sidenote. Любопытно, что статус инвойса никогда не обновлялся по факту подтверждения платежа средствами аджастмента. И сейчас не станет правда, я с этим ничего не делал пока, нужно будет обсудить логику если вдруг решим, что это важно.