### PR TITLE
MSPF-561 Update damsel

### DIFF
--- a/apps/hellgate/src/hg_routing.erl
+++ b/apps/hellgate/src/hg_routing.erl
@@ -493,7 +493,7 @@ score_risk_coverage(Terminal, VS) ->
 
 get_payments_terms(?route(ProviderRef, TerminalRef), Revision) ->
     #domain_Provider{payment_terms = Terms0} = hg_domain:get(Revision, {provider, ProviderRef}),
-    #domain_Terminal{terms = Terms1} = hg_domain:get(Revision, {terminal, TerminalRef}),
+    #domain_Terminal{terms_legacy = Terms1} = hg_domain:get(Revision, {terminal, TerminalRef}),
     merge_payment_terms(Terms0, Terms1).
 
 -spec get_rec_paytools_terms(route(), hg_domain:revision()) -> terms().
@@ -574,7 +574,7 @@ collect_routes_for_provider(Predestination, {ProviderRef, Provider}, VS, Revisio
 
 acceptable_terminal(payment, TerminalRef, #domain_Provider{payment_terms = Terms0}, VS, Revision) ->
     Terminal = #domain_Terminal{
-        terms         = Terms1,
+        terms_legacy  = Terms1,
         risk_coverage = RiskCoverage
     } = hg_domain:get(Revision, {terminal, TerminalRef}),
     % TODO the ability to override any terms makes for uncommon sense
@@ -597,7 +597,7 @@ acceptable_terminal(recurrent_payment, TerminalRef, Provider, VS, Revision) ->
         recurrent_paytool_terms = RecurrentTerms
     } = Provider,
     Terminal = #domain_Terminal{
-        terms         = TerminalTerms,
+        terms_legacy  = TerminalTerms,
         risk_coverage = RiskCoverage
     } = hg_domain:get(Revision, {terminal, TerminalRef}),
     PaymentTerms = merge_payment_terms(PaymentTerms0, TerminalTerms),

--- a/apps/hellgate/test/hg_invoice_tests_SUITE.erl
+++ b/apps/hellgate/test/hg_invoice_tests_SUITE.erl
@@ -4409,7 +4409,7 @@ adhoc_repair_invalid_changes_failed(C) ->
     [
         ?payment_ev(PaymentID, ?session_ev(?processed(), ?trx_bound(?trx_info(PaymentID))))
     ] = next_event(InvoiceID, Client),
-    timeout = next_event(InvoiceID, 1000, Client),
+    timeout = next_event(InvoiceID, 5000, Client),
     InvalidChanges1 = [
         ?payment_ev(PaymentID, ?refund_ev(<<"42">>, ?refund_status_changed(?refund_succeeded())))
     ],

--- a/apps/hellgate/test/hg_invoice_tests_SUITE.erl
+++ b/apps/hellgate/test/hg_invoice_tests_SUITE.erl
@@ -6149,7 +6149,7 @@ construct_domain_fixture() ->
                 name = <<"Drominal 1">>,
                 description = <<"Drominal 1">>,
                 risk_coverage = low,
-                terms = #domain_PaymentsProvisionTerms{
+                terms_legacy = #domain_PaymentsProvisionTerms{
                     currencies = {value, ?ordset([
                         ?cur(<<"RUB">>)
                     ])},
@@ -6190,7 +6190,7 @@ construct_domain_fixture() ->
                 name = <<"Terminal 7">>,
                 description = <<"Terminal 7">>,
                 risk_coverage = high,
-                terms = #domain_PaymentsProvisionTerms{
+                terms_legacy = #domain_PaymentsProvisionTerms{
                     cash_flow = {value, [
                         ?cfpost(
                             {provider, settlement},

--- a/apps/hellgate/test/hg_route_rules_tests_SUITE.erl
+++ b/apps/hellgate/test/hg_route_rules_tests_SUITE.erl
@@ -440,7 +440,7 @@ construct_domain_fixture() ->
                 name = <<"Drominal 1">>,
                 description = <<"Drominal 1">>,
                 risk_coverage = low,
-                terms = #domain_PaymentsProvisionTerms{
+                terms_legacy = #domain_PaymentsProvisionTerms{
                     currencies = {value, ?ordset([
                         ?cur(<<"RUB">>)
                     ])},

--- a/apps/hellgate/test/hg_routing_tests_SUITE.erl
+++ b/apps/hellgate/test/hg_routing_tests_SUITE.erl
@@ -1361,7 +1361,7 @@ construct_domain_fixture() ->
                 name = <<"Drominal 1">>,
                 description = <<"Drominal 1">>,
                 risk_coverage = low,
-                terms = #domain_PaymentsProvisionTerms{
+                terms_legacy = #domain_PaymentsProvisionTerms{
                     currencies = {value, ?ordset([
                         ?cur(<<"RUB">>)
                     ])},

--- a/apps/party_management/src/pm_provider.erl
+++ b/apps/party_management/src/pm_provider.erl
@@ -46,7 +46,7 @@ reduce_payment_provider(Provider, VS, DomainRevision) ->
 
 reduce_payment_provider_terminal_terms(Provider, Terminal, VS, DomainRevision) ->
     ProviderPaymentTerms = Provider#domain_Provider.payment_terms,
-    TerminalPaymentTerms = Terminal#domain_Terminal.terms,
+    TerminalPaymentTerms = Terminal#domain_Terminal.terms_legacy,
     MergedPaymentTerms = merge_payment_terms(ProviderPaymentTerms, TerminalPaymentTerms),
     reduce_payment_terms(MergedPaymentTerms, VS, DomainRevision).
 

--- a/apps/party_management/test/pm_party_tests_SUITE.erl
+++ b/apps/party_management/test/pm_party_tests_SUITE.erl
@@ -2412,7 +2412,7 @@ construct_domain_fixture() ->
                 name = <<"Brominal 1">>,
                 description = <<"Brominal 1">>,
                 risk_coverage = high,
-                terms = #domain_PaymentsProvisionTerms{
+                terms_legacy = #domain_PaymentsProvisionTerms{
                     payment_methods = {value, ?ordset([
                         ?pmt(bank_card, visa)
                     ])}

--- a/rebar.lock
+++ b/rebar.lock
@@ -10,7 +10,7 @@
  {<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.8.0">>},2},
  {<<"damsel">>,
   {git,"git@github.com:rbkmoney/damsel.git",
-       {ref,"e9c18627e5cc5d6d95dbd820b323bf6165b0782e"}},
+       {ref,"f31c36e83c484c21f9de05d3b753620d043ed888"}},
   0},
  {<<"dmt_client">>,
   {git,"git@github.com:rbkmoney/dmt_client.git",


### PR DESCRIPTION
Обновление `damsel` без использования новых полей протокола. Сделано, чтобы быть полностью совместимым с обеими версиями `damsel`.