### PR TITLE
Fix: Rollback to an old image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,10 @@ SERVICE_IMAGE_PUSH_TAG ?= $(SERVICE_IMAGE_TAG)
 
 # Base image for the service
 BASE_IMAGE_NAME := service-erlang
-BASE_IMAGE_TAG := 02a14b0cf68de5552e03a4f66f771411ff7964f8
+BASE_IMAGE_TAG := da0ab769f01b650b389d18fc85e7418e727cbe96
 
 # Build image tag to be used
-BUILD_IMAGE_NAME := build-erlang
-BUILD_IMAGE_TAG := 491bc06c745a07c6fe9e8b5dbbe958e8e0b82c4c
+BUILD_IMAGE_TAG := 442c2c274c1d8e484e5213089906a4271641d95e
 
 CALL_ANYWHERE := all submodules rebar-update compile xref lint dialyze plt_update \
 				start devrel release clean distclean format check_format


### PR DESCRIPTION
Новый image привнес ошибки резолвинга имен сервисов, пока его не починили, разумно будет откатиться на предыдущий