### PR TITLE
Avoid warnings spam w/ incompatible cash ranges

### DIFF
--- a/apps/hellgate/test/hg_invoice_tests_SUITE.erl
+++ b/apps/hellgate/test/hg_invoice_tests_SUITE.erl
@@ -1334,7 +1334,7 @@ payment_w_customer_success(C) ->
     Client = cfg(client, C),
     PartyID = cfg(party_id, C),
     ShopID = cfg(shop_id, C),
-    InvoiceID = start_invoice(<<"rubberduck">>, make_due_date(10), 42000, C),
+    InvoiceID = start_invoice(<<"rubberduck">>, make_due_date(60), 42000, C),
     CustomerID = make_customer_w_rec_tool(PartyID, ShopID, cfg(customer_client, C)),
     PaymentParams = make_customer_payment_params(CustomerID),
     PaymentID = process_payment(InvoiceID, PaymentParams, Client),
@@ -1351,7 +1351,7 @@ payment_w_another_shop_customer(C) ->
     ShopID = cfg(shop_id, C),
     PartyClient = cfg(party_client, C),
     AnotherShopID = hg_ct_helper:create_battle_ready_shop(?cat(2), <<"RUB">>, ?tmpl(2), ?pinst(2), PartyClient),
-    InvoiceID = start_invoice(AnotherShopID, <<"rubberduck">>, make_due_date(10), 42000, C),
+    InvoiceID = start_invoice(AnotherShopID, <<"rubberduck">>, make_due_date(60), 42000, C),
     CustomerID = make_customer_w_rec_tool(PartyID, ShopID, cfg(customer_client, C)),
     PaymentParams = make_customer_payment_params(CustomerID),
     {exception, #'InvalidRequest'{}} = hg_client_invoicing:start_payment(InvoiceID, PaymentParams, Client).
@@ -1363,7 +1363,7 @@ payment_w_another_party_customer(C) ->
     ShopID = cfg(shop_id, C),
     AnotherShopID = cfg(another_shop_id, C),
     CustomerID = make_customer_w_rec_tool(AnotherPartyID, AnotherShopID, cfg(another_customer_client, C)),
-    InvoiceID = start_invoice(ShopID, <<"rubberduck">>, make_due_date(10), 42000, C),
+    InvoiceID = start_invoice(ShopID, <<"rubberduck">>, make_due_date(60), 42000, C),
     PaymentParams = make_customer_payment_params(CustomerID),
     {exception, #'InvalidRequest'{}} = hg_client_invoicing:start_payment(InvoiceID, PaymentParams, Client).
 
@@ -1373,7 +1373,7 @@ payment_w_deleted_customer(C) ->
     CustomerClient = cfg(customer_client, C),
     PartyID = cfg(party_id, C),
     ShopID = cfg(shop_id, C),
-    InvoiceID = start_invoice(<<"rubberduck">>, make_due_date(10), 42000, C),
+    InvoiceID = start_invoice(<<"rubberduck">>, make_due_date(60), 42000, C),
     CustomerID = make_customer_w_rec_tool(PartyID, ShopID, CustomerClient),
     ok = hg_client_customer:delete(CustomerID, CustomerClient),
     PaymentParams = make_customer_payment_params(CustomerID),

--- a/apps/party_management/src/pm_cash_range.erl
+++ b/apps/party_management/src/pm_cash_range.erl
@@ -9,8 +9,8 @@
 -type cash_range() :: dmsl_domain_thrift:'CashRange'().
 -type cash() :: dmsl_domain_thrift:'Cash'().
 
--spec is_inside(cash(), cash_range()) -> within | {exceeds, lower | upper}.
-is_inside(Cash, CashRange = #domain_CashRange{lower = Lower, upper = Upper}) ->
+-spec is_inside(cash(), cash_range()) -> within | {exceeds, lower | upper} | {error, incompatible}.
+is_inside(Cash, #domain_CashRange{lower = Lower, upper = Upper}) ->
     case
         {
             compare_cash(fun erlang:'>'/2, Cash, Lower),
@@ -24,8 +24,7 @@ is_inside(Cash, CashRange = #domain_CashRange{lower = Lower, upper = Upper}) ->
         {true, false} ->
             {exceeds, upper};
         _ ->
-            logger:warning("Invalid cash range specified, ~p, ~p", [CashRange, Cash]),
-            undefined
+            {error, incompatible}
     end.
 
 compare_cash(_, V, {inclusive, V}) ->


### PR DESCRIPTION
Prefer to return well-specified error tuple instead.