### PR TITLE
Change severity of cash range check fail to debug

### DIFF
--- a/apps/party_management/src/pm_cash_range.erl
+++ b/apps/party_management/src/pm_cash_range.erl
@@ -24,7 +24,7 @@ is_inside(Cash, CashRange = #domain_CashRange{lower = Lower, upper = Upper}) ->
         {true, false} ->
             {exceeds, upper};
         _ ->
-            logger:warning("Invalid cash range specified, ~p, ~p", [CashRange, Cash]),
+            logger:debug("Invalid cash range specified, ~p, ~p", [CashRange, Cash]),
             undefined
     end.
 


### PR DESCRIPTION
Usually, the transaction currency is checked after the terms have been fully calculated in PM. Therefore, the situation when the currency does not fit CashRange is normal. So a message about this should not be issued with a warning log level.