### PR TITLE
Remove risk score overwriting when make_recurrent flag is set

### DIFF
--- a/apps/hellgate/src/hg_invoice_payment.erl
+++ b/apps/hellgate/src/hg_invoice_payment.erl
@@ -3435,9 +3435,7 @@ get_route_provider(Route, Revision) ->
 inspect(Payment = #domain_InvoicePayment{domain_revision = Revision}, PaymentInstitution, Opts) ->
     InspectorRef = get_selector_value(inspector, PaymentInstitution#domain_PaymentInstitution.inspector),
     Inspector = hg_domain:get(Revision, {inspector, InspectorRef}),
-    RiskScore = hg_inspector:inspect(get_shop(Opts), get_invoice(Opts), Payment, Inspector),
-    % FIXME: move this logic to inspector
-    check_payment_type_risk(RiskScore, Payment).
+    hg_inspector:inspect(get_shop(Opts), get_invoice(Opts), Payment, Inspector).
 
 repair_inspect(Payment, PaymentInstitution, Opts, #st{repair_scenario = Scenario}) ->
     case hg_invoice_repair:check_for_action(skip_inspector, Scenario) of
@@ -3446,11 +3444,6 @@ repair_inspect(Payment, PaymentInstitution, Opts, #st{repair_scenario = Scenario
         call ->
             inspect(Payment, PaymentInstitution, Opts)
     end.
-
-check_payment_type_risk(low, #domain_InvoicePayment{make_recurrent = true}) ->
-    high;
-check_payment_type_risk(Score, _Payment) ->
-    Score.
 
 get_st_meta(#st{payment = #domain_InvoicePayment{id = ID}}) ->
     #{

--- a/apps/hellgate/test/hg_direct_recurrent_tests_SUITE.erl
+++ b/apps/hellgate/test/hg_direct_recurrent_tests_SUITE.erl
@@ -30,7 +30,6 @@
 -export([not_permitted_recurrent_test/1]).
 -export([not_exists_invoice_test/1]).
 -export([not_exists_payment_test/1]).
--export([recurrent_risk_score_always_high/1]).
 
 %% Internal types
 
@@ -90,8 +89,7 @@ groups() ->
             customer_paytools_as_first_test,
             cancelled_first_payment_test,
             not_exists_invoice_test,
-            not_exists_payment_test,
-            recurrent_risk_score_always_high
+            not_exists_payment_test
         ]},
         {domain_affecting_operations, [], [
             not_permitted_recurrent_test
@@ -282,18 +280,6 @@ not_exists_payment_test(C) ->
     PaymentParams = make_payment_params(true, RecurrentParent),
     ExpectedError = #payproc_InvalidRecurrentParentPayment{details = <<"Parent payment not found">>},
     {error, ExpectedError} = start_payment(InvoiceID, PaymentParams, Client).
-
--spec recurrent_risk_score_always_high(config()) -> test_result().
-recurrent_risk_score_always_high(C) ->
-    Client = cfg(client, C),
-    InvoiceID = start_invoice(<<"rubberduck">>, make_due_date(10), 42000, C),
-    PaymentParams = make_payment_params(),
-    {ok, PaymentID} = start_payment(InvoiceID, PaymentParams, Client),
-    Pattern = [
-        ?evp(?payment_ev(PaymentID, ?risk_score_changed(_)))
-    ],
-    {ok, [?payment_ev(PaymentID, ?risk_score_changed(Score))]} = await_events(InvoiceID, Pattern, Client),
-    high = Score.
 
 %% Internal functions
 


### PR DESCRIPTION
Повышение оценки риска больше не нужно. Это никогда не использовалось по назначению и затрудняет управление платежами средствами антифрода.